### PR TITLE
Changed comment in build.js

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -10,8 +10,8 @@
     "mainConfigFile": "../www/js/app.js",
 
     "modules": [
-        //Optimize the application files. jQuery is not 
-        //included since it is already in require-jquery.js
+        //Optimize the application files. jQuery and the plugins will be included
+        //automatically, as they are dependencies of app.js.
         {
             "name": "app"
         }


### PR DESCRIPTION
IMHO the comment about not including jQuery in the module is wrong, as it's included autmatically, as it's a dependency of the app module. Seems to be some copy/paste error.
