### PR TITLE
Update comment about IE6-8 based on new jQuery minor version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If the plugins you use all call [define()](http://requirejs.org/docs/api.html#de
 
 The most important part of this example is the app.js file, which specifies the [shim configuration](http://requirejs.org/docs/api.html#config-shim) for the plugins.
 
-**If you want IE6-8 support**, clone this repo, but replace the jQuery file with a jQuery 1.9 release. The jQuery 2 used in this project does not work with those browsers, a 1.9 release is needed.
+**If you want IE6-8 support**, clone this repo, but replace the jQuery file with the latest jQuery 1.x release. The jQuery 2 file used in this project does not work with those browsers.
 
 ###Project structure
 


### PR DESCRIPTION
- Make description more future-proof by substituting generic “1.x” description in place of “1.9”
- Remove redundant final clause in the second sentence of the IE6-8 note
