### PR TITLE
minor fix for visit directory

### DIFF
--- a/tools/server.js
+++ b/tools/server.js
@@ -18,20 +18,31 @@ http.createServer(function (request, response) {
     var uri = url.parse(request.url).pathname,
         filename = path.join(__dirname, '..', uri);
 
-    fs.exists(filename, function (exists) {
-        if (!exists) {
-            response.writeHead(404, {'Content-Type': 'text/plain'});
-            response.write('404 Not Found\n');
-            response.end();
-            return;
-        }
+    if(!fs.lstatSync(filename).isDirectory()) {
+        fs.exists(filename, function (exists) {
+            if (!exists) {
+                response.writeHead(404, {'Content-Type': 'text/plain'});
+                response.write('404 Not Found\n');
+                response.end();
+                return;
+            }
 
-        var type = filename.split('.');
-        type = type[type.length - 1];
+            var type = filename.split('.');
+            type = type[type.length - 1];
 
-        response.writeHead(200, { 'Content-Type': types[type] + '; charset=utf-8' });
-        fs.createReadStream(filename).pipe(response);
-    });
+            response.writeHead(200, { 'Content-Type': types[type] + '; charset=utf-8' });
+            fs.createReadStream(filename).pipe(response);
+        });
+    } else {
+        /**
+         * if users visit the site such as http://localhost:8888
+         * then lead them to http://localhost:8888/www/app.html
+         *
+         */
+        response.writeHead(200, {'Content-Type': 'text/html'});
+        response.write('Please visit <a href="www/app.html">here</a>\n');
+        response.end();
+    }
 }).listen(parseInt(port, 10));
 
 console.log('Static file server running at\n  => http://localhost:' + port + '/\nCTRL + C to shutdown');


### PR DESCRIPTION
When user visit http://localhost:8888/, the node server will throw errors and halt because of the directory visit, so we need to check if the visit resource is file or directory, and lead users to the destination
